### PR TITLE
Fix a bug due to PCRE2 version difference

### DIFF
--- a/src/Util/FuriganaKugiri.php
+++ b/src/Util/FuriganaKugiri.php
@@ -114,7 +114,7 @@ class FuriganaKugiri
          *     "｜" で区切ることになる状況が多いのではないだろうか。これを踏まえて
          *     パターンの優先順位は最後にしておく。
          */
-        'hiragana' => '((?:\p{sc=Hiragana}+[゛゜]*)+)',
+        'hiragana' => '((?:[\x{3040}-\x{3096}\x{309D}-\x{309F}]+[゛゜]*)+)',
     ];
 
     public function getKugiri(): array


### PR DESCRIPTION
- 前回コミットした `hiragana` のパターンはPCRE2のver10.40以降に追加されたことから10.40以前でも使える書き方に変更
    - 広報互換性は何処まで残すべきなのかは正直分からないが、注釈が入っている限り古典的な書き方でも分かりづらいことは無いはず