### PR TITLE
Update test class for cover `FuriganaEscapeParser`

### DIFF
--- a/tests/FuriganaEscapeTest.php
+++ b/tests/FuriganaEscapeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Copyright 2023 Jan stanray watt
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *  http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace JSW\Tests;
+
+use JSW\Furigana\FuriganaExtension;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\MarkdownConverter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \JSW\Hurigana\Parser\HuriganaEscapeParser
+ *
+ * @group unit
+ * @group jisage
+ */
+final class FuriganaEscapeTest extends TestCase
+{
+    private const DEFAULT_RULE = [
+            'hurigana' => [
+                'use_sutegana' => false,
+                'use_rp_tag' => false,
+            ],
+    ];
+
+    /**
+     * @covers ::parse
+     */
+    public function testEscapeOpenDelimiter(): void
+    {
+        $environment = new Environment($this::DEFAULT_RULE);
+
+        $environment->addExtension(new CommonMarkCoreExtension())
+                    ->addExtension(new FuriganaExtension());
+
+        $converter = new MarkdownConverter($environment);
+
+        $expect = '<p>｜この拡張<ruby>機能<rt>きのう</rt></ruby>は素晴らしい</p>'."\n";
+        $actual = $converter->convert('\｜この拡張｜機能《きのう》は素晴らしい')->getContent();
+
+        $this->assertSame($expect, $actual);
+    }
+}

--- a/tests/FuriganaEscapeTest.php
+++ b/tests/FuriganaEscapeTest.php
@@ -27,7 +27,7 @@ use League\CommonMark\MarkdownConverter;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @coversDefaultClass \JSW\Hurigana\Parser\HuriganaEscapeParser
+ * @coversDefaultClass \JSW\Hurigana\Parser\FuriganaEscapeParser
  *
  * @group unit
  * @group jisage
@@ -41,6 +41,11 @@ final class FuriganaEscapeTest extends TestCase
             ],
     ];
 
+    private function makeExpect(string $expect)
+    {
+        return '<p>'.$expect.'</p>'."\n";
+    }
+
     /**
      * @covers ::parse
      */
@@ -53,8 +58,44 @@ final class FuriganaEscapeTest extends TestCase
 
         $converter = new MarkdownConverter($environment);
 
-        $expect = '<p>｜この拡張<ruby>機能<rt>きのう</rt></ruby>は素晴らしい</p>'."\n";
+        $expect = $this->makeExpect('｜この拡張<ruby>機能<rt>きのう</rt></ruby>は素晴らしい');
         $actual = $converter->convert('\｜この拡張｜機能《きのう》は素晴らしい')->getContent();
+
+        $this->assertSame($expect, $actual);
+    }
+
+    /**
+     * @covers ::parse
+     */
+    public function testEscapeRubyTextDelimiter(): void
+    {
+        $environment = new Environment($this::DEFAULT_RULE);
+
+        $environment->addExtension(new CommonMarkCoreExtension())
+                    ->addExtension(new FuriganaExtension());
+
+        $converter = new MarkdownConverter($environment);
+
+        $expect = $this->makeExpect('この拡張《<ruby>機能<rt>きのう</rt></ruby>は素晴らしい');
+        $actual = $converter->convert('この拡張\《機能《きのう》は素晴らしい')->getContent();
+
+        $this->assertSame($expect, $actual);
+    }
+
+    /**
+     * @covers ::parse
+     */
+    public function testEscapeCloseDelimiter(): void
+    {
+        $environment = new Environment($this::DEFAULT_RULE);
+
+        $environment->addExtension(new CommonMarkCoreExtension())
+                    ->addExtension(new FuriganaExtension());
+
+        $converter = new MarkdownConverter($environment);
+
+        $expect = $this->makeExpect('この<ruby>拡張機能<rt>き》のう</rt></ruby>は素晴らしい');
+        $actual = $converter->convert('この拡張機能《き\》のう》は素晴らしい')->getContent();
 
         $this->assertSame($expect, $actual);
     }

--- a/tests/FuriganaRubyTextTest.php
+++ b/tests/FuriganaRubyTextTest.php
@@ -21,11 +21,9 @@ declare(strict_types=1);
 namespace JSW\Tests;
 
 use JSW\Furigana\FuriganaExtension;
-use JSW\Furigana\Node\RubyText;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\MarkdownConverter;
-use League\CommonMark\Node\Block\Document;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -45,16 +43,6 @@ final class FuriganaRubyTextTest extends TestCase
     private function makeExpect(string $expect)
     {
         return '<p>'.$expect.'</p>'."\n";
-    }
-
-    private function digData(Document $document): int
-    {
-        $answer = -1;
-        foreach ($document->iterator() as $node) {
-            if ($node instanceof RubyText) {
-                return $node->data->get('text_length', -1);
-            }
-        }
     }
 
     /**

--- a/tests/FuriganaTest.php
+++ b/tests/FuriganaTest.php
@@ -193,7 +193,7 @@ final class FuriganaTest extends TestCase
     }
 
     /**
-     * @covers ::useRPTag
+     * @covers ::process
      */
     public function testRubyParentheses(): void
     {


### PR DESCRIPTION
- Rename class from `FuriganaSimpleTest` to `FuriganaEscapeTest`
- Remove a method `digData` no longer use
- メソッド`makeExpect`を追加
- 「《」、「》」に対応したテストメソッドを追加